### PR TITLE
Make BepInEx/ValheimPlus updaters resilient to transient API failures (fixes #778)

### DIFF
--- a/bepinex-updater
+++ b/bepinex-updater
@@ -15,7 +15,11 @@ main() {
     local download_url
     local remote_updated_at
 
-    if ! api_response=$(curl -sfSL -H "accept: application/json" "https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/"); then
+    if ! api_response=$(curl -sfSL \
+            --retry 5 --retry-delay 5 --retry-all-errors --retry-max-time 90 \
+            -A "valheim-server-docker" \
+            -H "accept: application/json" \
+            "https://thunderstore.io/api/experimental/package/denikson/BepInExPack_Valheim/"); then
         fatal "Error: could not retrieve BepInEx release info from Thunderstore.io API"
     fi
     download_url=$(jq -r  ".latest.download_url" <<< "$api_response" )

--- a/valheim-plus-updater
+++ b/valheim-plus-updater
@@ -15,7 +15,10 @@ main() {
     local download_url
     local remote_updated_at
 
-    if ! api_response=$(curl -sfSL "https://api.github.com/repos/$VALHEIM_PLUS_REPO/releases/$VALHEIM_PLUS_RELEASE"); then
+    if ! api_response=$(curl -sfSL \
+            --retry 5 --retry-delay 5 --retry-all-errors --retry-max-time 90 \
+            -A "valheim-server-docker" \
+            "https://api.github.com/repos/$VALHEIM_PLUS_REPO/releases/$VALHEIM_PLUS_RELEASE"); then
         fatal "Error: could not retrieve ValheimPlus release info from Github API"
     fi
     api_response=$(jq -r ".assets[] | select(.name == \"$vp_zipfile\")" <<< "$api_response" )

--- a/valheim-updater
+++ b/valheim-updater
@@ -108,6 +108,10 @@ check_mod() {
             touch "$mod_mergefile"
         fi
         if ! just_started=$just_started "$mod_updater"; then
+            if [ -f "$mod_install_path/valheim_server.x86_64" ]; then
+                warn "Failed to run $mod_name updater - however an existing installation was found at $mod_install_path - using it"
+                return 0
+            fi
             error "Failed to run $mod_name updater - retrying later - check your networking and volume access permissions"
             return 1
         fi


### PR DESCRIPTION
## Summary

Fixes #778. Issue reporter saw a transient `HTTP 403` from Thunderstore's API on container restart, which permanently blocked the Valheim server from starting (workaround was disabling `BEPINEX`).

Thunderstore.io (BepInEx) and the GitHub releases API (ValheimPlus) both sit behind CDNs/WAFs that intermittently 403/429/5xx automated clients, especially on default `curl` User-Agent. The previous code did a single one-shot `curl` with no retry and no fallback, so any blip cascaded into a startup outage:

1. `bepinex-updater` (or `valheim-plus-updater`) calls `fatal` and exits 1.
2. `check_mod` in `valheim-updater` returns non-zero.
3. `update()` bails out **before** `write_restart_file`.
4. `check_server_restart` never sees a restart marker, so `supervisorctl start valheim-server` is never called.
5. Server stays down until the next `UPDATE_CRON` tick succeeds.

This is asymmetric with the existing Steam-download path in `update()` (`valheim-updater:51-58`), which already falls back to a locally-cached `valheim_server.x86_64` when Steam fails.

## Changes

- **`bepinex-updater`** / **`valheim-plus-updater`**: Add `curl --retry 5 --retry-delay 5 --retry-all-errors --retry-max-time 90` and a stable `User-Agent: valheim-server-docker` to both API calls. `--retry-all-errors` requires curl >= 7.71 (trixie ships 8.x, so fine).
- **`valheim-updater`** (`check_mod`): When the mod updater fails and `$mod_install_path/valheim_server.x86_64` already exists from a previous successful merge, log a warning and return 0 instead of blocking the boot. The next `UPDATE_CRON` tick still gets a chance to apply updates.

The "mod disabled but previously installed" refresh branch in `check_mod` is intentionally left alone — it's an opportunistic refresh and isn't load-bearing for server startup.