### PR TITLE
fix: create /var/run/valheim at runtime to prevent supervisord PID file boot loop

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -24,6 +24,7 @@ apply_permissions() {
     #usermod -u "${PUID}" -o -g valheim valheim
     sed -i -E "s/^(valheim:x):[0-9]+:[0-9]+:(.*)/\\1:$PUID:$PGID:\\2/" /etc/passwd
 
+    mkdir -p /var/run/valheim
     touch "$SERVER_STATUS_FILE"
 
     chown -R valheim:valheim \


### PR DESCRIPTION
## Problem

When `/var/run` is a tmpfs (common with systemd-nspawn, podman, or `--tmpfs /var/run`), the `/var/run/valheim` directory created at Dockerfile build time is lost at runtime. Every supervisord-managed process then fails its `check_lock()` call because the pidfile directory doesn't exist:

```
/usr/local/etc/valheim/common: line 214: /var/run/valheim/valheim-updater.pid: No such file or directory
WARN - Predecessor PID is corrupt - clearing lock and running
```

This causes supervisord to restart `valheim-updater` and `valheim-backup` in an infinite loop — SteamCMD is never reached, and the server never downloads.

## Root Cause

The `bootstrap` script's `apply_permissions()` function touches `$SERVER_STATUS_FILE` and `chown`'s `/var/run/valheim` but **never creates the directory**. It relies on the directory existing from the Dockerfile `mkdir -p` (line 146), which is lost on tmpfs `/var/run`.

## Fix

One line — add `mkdir -p /var/run/valheim` before the `touch` and `chown`:

```diff
+    mkdir -p /var/run/valheim
     touch "$SERVER_STATUS_FILE"
```

## Testing

**Before (broken):**
```
Jun 15 08:13:11 supervisord: valheim-updater WARN - Predecessor PID is corrupt - clearing lock and running
Jun 15 08:13:11 supervisord: valheim-updater INFO - Releasing PID file /var/run/valheim/valheim-updater.pid
... (repeats forever, SteamCMD never starts — ~70 log lines/second)
```

**After (fixed):**
```
INFO - Setting uid:gid of valheim to 0:0
INFO - Setting timezone Etc/UTC
INFO - Downloading/updating/validating Valheim server from Steam
Steam Console Client (c) Valve Corporation - version 1773426366
Connecting anonymously to Steam Public...
[  0%] Checking for available updates...
```

No PID file errors. SteamCMD starts immediately. Server downloads and starts successfully. Tested on containerd with host networking (tmpfs `/var/run`).

## Files Changed
- `bootstrap` — 1 line added (`mkdir -p /var/run/valheim`)