### PR TITLE
Fix DEBUG_START_FRESH cleanup

### DIFF
--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -21,7 +21,7 @@ fi
 # check if we are supposed to wipe our data directories
 if [ "$DEBUG_START_FRESH" = true ]; then
     warn "Wiping all data directories (DEBUG_START_FRESH: $DEBUG_START_FRESH)"
-    rm -rf "/opt/valheim/*"
+    rm -rf /opt/valheim/*
 fi
 
 # check if we are supposed to reinstall ValheimPlus


### PR DESCRIPTION
Fixes `DEBUG_START_FRESH` not properly clearing `/opt/valheim`.

The glob was quoted, preventing it from being expanded and leaving the existing server data untouched.
