### PR TITLE
Fix datetime.utcnow() deprecation warning in valheim-status

### DIFF
--- a/valheim-status
+++ b/valheim-status
@@ -84,7 +84,7 @@ def write_status(status: str, status_file: str) -> None:
 
 def get_status(query_host: str, query_port: int) -> Dict:
     status = {
-        "last_status_update": datetime.utcnow().replace(tzinfo=timezone.utc),
+        "last_status_update": datetime.now(timezone.utc),
         "error": None,
     }
     try:


### PR DESCRIPTION
I noticed a warning in my server logs. Replaced `datetime.utcnow().replace(tzinfo=timezone.utc)` with `datetime.now(timezone.utc)`. The timestamp remains in UTC with the same output format.