### PR TITLE
fix: detect CROSSPLAY=true in idle checks

### DIFF
--- a/common
+++ b/common
@@ -161,7 +161,7 @@ _udp_datagram_count() {
 
 
 server_is_crossplay() {
-    [[ "${SERVER_ARGS,,}" =~ "-crossplay" ]];
+    [[ "$CROSSPLAY" = true || "${SERVER_ARGS,,}" =~ "-crossplay" ]]
 }
 
 

--- a/valheim-tests
+++ b/valheim-tests
@@ -67,6 +67,4 @@ main() {
 }
 
 test_server_is_crossplay || exit 1
-if [ "${1:-}" != "--crossplay-only" ]; then
-    main
-fi
+main

--- a/valheim-tests
+++ b/valheim-tests
@@ -2,6 +2,26 @@
 . /usr/local/etc/valheim/defaults
 . /usr/local/etc/valheim/common
 
+test_server_is_crossplay() {
+    if ! (CROSSPLAY=true; SERVER_ARGS="-saveinterval 1800"; server_is_crossplay); then
+        echo "CROSSPLAY=true should enable crossplay detection"
+        return 1
+    fi
+    if ! (CROSSPLAY=false; SERVER_ARGS="-saveinterval 1800 -crossplay"; server_is_crossplay); then
+        echo "SERVER_ARGS=-crossplay should enable crossplay detection"
+        return 1
+    fi
+    if ! (CROSSPLAY=false; SERVER_ARGS="-saveinterval 1800 -CROSSPLAY"; server_is_crossplay); then
+        echo "SERVER_ARGS=-CROSSPLAY should enable crossplay detection"
+        return 1
+    fi
+    if (CROSSPLAY=false; SERVER_ARGS="-saveinterval 1800"; server_is_crossplay); then
+        echo "Crossplay detection should be disabled without CROSSPLAY=true or -crossplay"
+        return 1
+    fi
+    echo "Crossplay detection tests passed"
+}
+
 main() {
     timeout=900
     echo "Running tests..."
@@ -46,4 +66,7 @@ main() {
     exit 0
 }
 
-main
+test_server_is_crossplay || exit 1
+if [ "${1:-}" != "--crossplay-only" ]; then
+    main
+fi


### PR DESCRIPTION
## Problem

When `CROSSPLAY=true`, the launcher adds `-crossplay` to the Valheim process, but `server_is_crossplay()` inspected only `SERVER_ARGS`. A normally configured crossplay server with no `-crossplay` in `SERVER_ARGS` was therefore classified as non-crossplay by `server_is_idle()`.

In a real runtime reproduction with one connected player, `server_is_crossplay()` returned false. `valheim-status` took the A2S path, timed out, and exited 0; `server_is_idle()` consequently returned true while the player was online. This PR does not change that A2S timeout/exit-code behavior.

## Root Cause

Both `CROSSPLAY=true` and manually passing `-crossplay` through `SERVER_ARGS` enable crossplay, but detection recognized only the latter.

## Fix

`server_is_crossplay()` now returns true when `CROSSPLAY=true` or `SERVER_ARGS` contains `-crossplay`. The existing case-insensitive `SERVER_ARGS` behavior is preserved.

## Testing

- Focused regression tests pass; against base `1c9a6ea`, they fail on `CROSSPLAY=true`. Manual `SERVER_ARGS=-crossplay` and uppercase `-CROSSPLAY` compatibility cases pass.
- `bash -n` and `git diff --check` pass. Docker image build and the Dockerfile ShellCheck stage passed.
- Real runtime acceptance test on Valheim 1.0.12 with crossplay/PlayFab, `CROSSPLAY=true`, and no `-crossplay` in `SERVER_ARGS` (patched image commit `3acd1646c7bc967c170b3c05a543e03634ddeff4`):
  - 0 players: `server_is_crossplay=true`; UDP sample `0`; `server_is_idle=true`.
  - 1 connected AFK player: ten 3-second UDP samples `204, 201, 208, 205, 206, 196, 206, 203, 204, 211`; all BUSY; `server_is_idle=false`.
  - 1 active player: ten 3-second UDP samples `208, 262, 245, 243, 240, 247, 232, 246, 252, 255`; all BUSY; `server_is_idle=false`.
  - After disconnect: ten 3-second UDP samples `0, 1, 0, 0, 2, 2, 0, 0, 1, 1`; all IDLE; `server_is_idle=true`.

This runtime test validates the existing `nstat` crossplay path in the tested environment; it does not establish that the UDP heuristic is universally reliable.

## Scope

No changes to `nstat` behavior, `valheim-status`, PlayFab implementation, updater/restart behavior, or backups. Related context: #773; this PR does not fully resolve it.