### PR TITLE
Install valheim's crontab from bootstrap so cron works under no-new-privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,6 @@ RUN groupadd -g "${PGID:-0}" -o valheim \
     && chown -R valheim:valheim /var/run/valheim \
     && chown -R root:root /opt/steamcmd \
     && chmod u=rwx,go=rx /opt/steamcmd/steamcmd.sh \
-    && chmod a+s /usr/local/bin/crontab \
     /opt/steamcmd/linux32/steamcmd \
     /opt/steamcmd/linux32/steamerrorreporter \
     /usr/bin/supervisord \

--- a/bootstrap
+++ b/bootstrap
@@ -13,6 +13,7 @@ main() {
     setup_supervisor_http_server
     setup_status_http_server
     pre_supervisor_hook
+    setup_crontab
     exec /usr/bin/tini -- /usr/local/bin/supervisord -c /usr/local/etc/supervisord.conf
 }
 
@@ -156,6 +157,44 @@ pre_supervisor_hook() {
         info "Running pre supervisor hook: $PRE_SUPERVISOR_HOOK"
         eval "$PRE_SUPERVISOR_HOOK"
     fi
+}
+
+
+# Install valheim's crontab as root, so busybox crontab needn't be suid
+setup_crontab() {
+    local crontab
+    crontab=$(mktemp)
+
+    { echo "SERVER_PUBLIC=$SERVER_PUBLIC"; \
+        echo "SERVER_PORT=$SERVER_PORT"; \
+        echo "STATUS_HTTP_HTDOCS=$STATUS_HTTP_HTDOCS"; } >> "$crontab"
+
+    if [ "$BACKUPS" = true ] && [ -n "$BACKUPS_CRON" ] && [ "$BACKUPS_INTERVAL" = "315360000" ]; then
+        debug "Creating cron to do world backups using schedule $BACKUPS_CRON"
+        echo "$BACKUPS_CRON [ -f \"$valheim_backup_pidfile\" ] && kill -HUP \$(cat $valheim_backup_pidfile)" >> "$crontab"
+    fi
+
+    if [ -n "$UPDATE_CRON" ] && [ "$UPDATE_INTERVAL" = "315360000" ]; then
+        debug "Creating cron to check for updates using schedule $UPDATE_CRON"
+        echo "$UPDATE_CRON [ -f \"$valheim_updater_pidfile\" ] && kill -HUP \$(cat $valheim_updater_pidfile)" >> "$crontab"
+    fi
+
+    if [ -n "$RESTART_CRON" ]; then
+        debug "Creating cron to restart valheim-server using schedule $RESTART_CRON"
+        if [ "$RESTART_IF_IDLE" = true ]; then
+            echo "$RESTART_CRON $cmd_valheim_is_idle && $cmd_supervisorctl restart valheim-server" >> "$crontab"
+        else
+            echo "$RESTART_CRON $cmd_supervisorctl restart valheim-server" >> "$crontab"
+        fi
+    else
+        debug "Environment variable RESTART_CRON is empty - no automatic valheim-server restart scheduled"
+    fi
+
+    # Via stdin: busybox would open a file argument as valheim, who can't read it
+    if ! crontab -u valheim - < "$crontab"; then
+        error "Failed to install crontab - scheduled backups, updates and restarts won't run"
+    fi
+    rm -f "$crontab"
 }
 
 

--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -78,36 +78,6 @@ write_adminlist
 write_bannedlist
 write_permittedlist
 
-# Create crontabs
-crontab=$(mktemp)
-
-{ echo "SERVER_PUBLIC=$SERVER_PUBLIC"; \
-    echo "SERVER_PORT=$SERVER_PORT"; \
-    echo "STATUS_HTTP_HTDOCS=$STATUS_HTTP_HTDOCS"; } >> "$crontab"
-
-if [ "$BACKUPS" = true ] && [ -n "$BACKUPS_CRON" ] && [ "$BACKUPS_INTERVAL" = "315360000" ]; then
-    debug "Creating cron to do world backups using schedule $BACKUPS_CRON"
-    echo "$BACKUPS_CRON [ -f \"$valheim_backup_pidfile\" ] && kill -HUP \$(cat $valheim_backup_pidfile)" >> "$crontab"
-fi
-
-if [ -n "$UPDATE_CRON" ] && [ "$UPDATE_INTERVAL" = "315360000" ]; then
-    debug "Creating cron to check for updates using schedule $UPDATE_CRON"
-    echo "$UPDATE_CRON [ -f \"$valheim_updater_pidfile\" ] && kill -HUP \$(cat $valheim_updater_pidfile)" >> "$crontab"
-fi
-
-if [ -n "$RESTART_CRON" ]; then
-    debug "Creating cron to restart valheim-server using schedule $RESTART_CRON"
-    if [ "$RESTART_IF_IDLE" = true ]; then
-        echo "$RESTART_CRON $cmd_valheim_is_idle && $cmd_supervisorctl restart valheim-server" >> "$crontab"
-    else
-        echo "$RESTART_CRON $cmd_supervisorctl restart valheim-server" >> "$crontab"
-    fi
-else
-    debug "Environment variable RESTART_CRON is empty - no automatic valheim-server restart scheduled"
-fi
-crontab "$crontab"
-rm -f "$crontab"
-
 
 # Notify users of new data paths
 if [ -d "/opt/valheim_dl" ] || [ -f "/opt/valheim/valheim_server.x86_64" ]; then


### PR DESCRIPTION
Since v1.2.0, scheduled backups, update checks and restarts silently stop for anyone running with a non-zero `PUID` under a runtime that ignores setuid bits. The only symptom is one line at startup:

`valheim-bootstrap crontab: must be suid to work properly`

`crond` runs normally with no crontab, so nothing else looks wrong. Users are likely to discover it when they reach for a backup that was never taken.

Fixes #805.

## Root cause

c900868 replaced Debian's cron with busybox's. Because busybox's `crontab` applet is `BB_SUID_REQUIRE`, that commit added `chmod a+s /usr/local/bin/crontab` and dropped `usermod -a -G crontab valheim`.

`valheim-bootstrap` runs as `valheim` (`supervisord.conf`), so installing a crontab now depended on that setuid bit. `no-new-privileges`, Kubernetes' `allowPrivilegeEscalation: false` (required by the restricted Pod Security Standard, and set by OpenShift's `restricted-v2` SCC) and `nosuid` mounts all make the kernel ignore it, leaving euid non-zero, and busybox refuses. `PUID` defaults to 0, where the check is skipped — which is why this wasn't caught.

Pre-1.2.0 was not relying on privilege escalation at all: Debian's `crontab` is *setgid*, which `no-new-privileges` ignores equally, and it worked only because `valheim` belonged to the `crontab` group (`3c75737`, added for #529 — the 2022 report of this same failure) and the spool is group-writable.

Two side effects of that `chmod a+s` are also fixed here. The path is a symlink, so the bit landed on the shared busybox binary itself; and the line inserted itself ahead of three continuation lines, so `steamcmd`, `steamerrorreporter` and `/usr/bin/supervisord` were silently made setuid/setgid instead of receiving the intended `755`.

## Change

`bootstrap` already runs as root before supervisord, so it now builds and installs the crontab there, and `valheim-bootstrap` no longer does. It's fed via stdin because busybox opens a file argument as the target user, who can't read root's temp file. A failed install is now logged as an error rather than passing unnoticed. `chmod a+s` is gone, so busybox is no longer setuid.

`supervisord.conf` is untouched — `crond` keeps its existing slot, command and `autostart`.

**Behaviour note:** `PRE_BOOTSTRAP_HOOK` can no longer influence `UPDATE_CRON`/`BACKUPS_CRON`/`RESTART_CRON`, since generation now happens earlier. That was never documented — it worked only because the hook is `eval`'d in the same shell. `PRE_SUPERVISOR_HOOK` can still do it.

## Testing

Verified under rootless Podman on x86_64 by layering the branch's files onto the published `1.2.0` image (v1.2.0 is this branch's base), confirming in each case that `crond` actually executed a job as `valheim`, not merely that a crontab file appeared:

| Scenario | Result |
|---|---|
| `PUID=1000` + `no-new-privileges` | crontab installed root-owned, job ran as uid 1000 |
| `PUID=0` + `no-new-privileges` | installed, job ran as uid 0 |
| `PUID=1000`, no flag | installed, job ran |
| Schedule set only via `PRE_BOOTSTRAP_HOOK` | not applied — expected, see note above |
| Install failure (spool directory removed) | `ERROR - Failed to install crontab …`; updater and backup keep running |
| Reproduction on unmodified `1.2.0` | `must be suid to work properly`, empty spool |
| Baseline `1.1.0` | works, via `crontab` group membership |
| `1.1.0` with `valheim` removed from that group | fails under the flag, confirming the setgid path is ignored |

`shellcheck` passes with the project's flags.

## Related

Builds on #785, which creates `/var/run/valheim` at runtime.
