### PR TITLE
fix: sync BepInEx plugins when pack no longer ships plugins/ dir (fixes #803)

### DIFF
--- a/common
+++ b/common
@@ -290,7 +290,12 @@ write_bepinex_config() {
         if env | grep "^$BEPINEX_CFG_ENV_PREFIX" > /dev/null; then
             /usr/local/bin/env2cfg --verbose --config "$config_path/BepInEx.cfg" --env-prefix "$BEPINEX_CFG_ENV_PREFIX"
         fi
-        if [ -d "$config_path/plugins" ] && [ -d "$plugins_path" ]; then
+        if [ -d "$config_path/plugins" ]; then
+            # denikson/BepInExPack_Valheim 5.4.2350 stopped shipping the empty
+            # BepInEx/plugins directory that earlier archives provided, so the
+            # destination may not exist after a fresh install and the sync would
+            # otherwise be silently skipped.
+            mkdir -p "$plugins_path"
             info "Syncing BepInEx plugins from $config_path/plugins/ -> $plugins_path"
             rsync -a --itemize-changes "$config_path/plugins/" "$plugins_path"
         fi

--- a/valheim-tests
+++ b/valheim-tests
@@ -2,7 +2,40 @@
 . /usr/local/etc/valheim/defaults
 . /usr/local/etc/valheim/common
 
+# Regression test for BepInEx plugin syncing.
+#
+# denikson/BepInExPack_Valheim 5.4.2350 stopped shipping an empty BepInEx/plugins
+# directory that earlier archives provided. write_bepinex_config() used to require
+# that destination to already exist, so on a fresh install the sync was silently
+# skipped and BepInEx loaded 0 plugins. This reproduces that precondition (an
+# extracted pack whose BepInEx/ has no plugins/ subdir) and asserts a plugin placed
+# in the config dir is synced into the install dir. It fails against the old code.
+test_bepinex_plugin_sync() {
+    local tmp config_path install_path plugins_path
+    echo "Testing BepInEx plugin sync..."
+    tmp=$(mktemp -d)
+    config_path="$tmp/config"
+    install_path="$tmp/install"
+    plugins_path="$install_path/BepInEx/plugins"
+    # A plugin waiting in the config dir, as a user would place it.
+    mkdir -p "$config_path/plugins"
+    touch "$config_path/BepInEx.cfg"
+    echo "dummy" > "$config_path/plugins/TestPlugin.dll"
+    # Simulate a freshly extracted 5.4.2350 pack: BepInEx/ exists, but no plugins/.
+    mkdir -p "$install_path/BepInEx"
+    write_bepinex_config "$config_path" "$plugins_path"
+    if [ -f "$plugins_path/TestPlugin.dll" ]; then
+        echo "BepInEx plugin sync OK: TestPlugin.dll synced to install dir"
+        rm -rf "$tmp"
+    else
+        echo "BepInEx plugin sync FAILED: TestPlugin.dll was not synced to $plugins_path"
+        rm -rf "$tmp"
+        exit 1
+    fi
+}
+
 main() {
+    scenario="${1:-default}"
     timeout=900
     echo "Running tests..."
     echo "Waiting up to $timeout seconds for server to start..."
@@ -42,8 +75,11 @@ main() {
             exit 1
         fi
     done
+    if [ "$scenario" = "bepinex" ]; then
+        test_bepinex_plugin_sync
+    fi
     echo "Tests passed!"
     exit 0
 }
 
-main
+main "$@"


### PR DESCRIPTION
## Problem

Fixes #803. On a fresh install, plugins in `/config/bepinex/plugins/` are not copied into `/opt/valheim/bepinex/BepInEx/plugins/`, so BepInEx logs `0 plugins to load`.

## Cause

`write_bepinex_config()` in `common` only syncs plugins if the destination already exists, and never creates it:

```sh
if [ -d "$config_path/plugins" ] && [ -d "$plugins_path" ]; then
    rsync -a --itemize-changes "$config_path/plugins/" "$plugins_path"
fi
```

This worked because every BepInExPack archive shipped an empty `BepInEx/plugins/` dir. **`denikson/BepInExPack_Valheim` 5.4.2350 stopped shipping it** (verified: present through 5.4.2202, gone in 5.4.2350), so the destination no longer exists at sync time and the sync is silently skipped.

## Fix

Create the destination before syncing:

```sh
if [ -d "$config_path/plugins" ]; then
    mkdir -p "$plugins_path"
    info "Syncing BepInEx plugins from $config_path/plugins/ -> $plugins_path"
    rsync -a --itemize-changes "$config_path/plugins/" "$plugins_path"
fi
```

No-op for older packs that still ship the directory.

## Test

The `bepinex` scenario in `valheim-tests` only waited for the server to listen — it never checked plugin syncing, which is why this regressed unnoticed. Adds an assertion reproducing the 5.4.2350 precondition (extracted pack with no `plugins/` subdir); it fails before the fix and passes after.
