### PR TITLE
Sync BepInEx patchers and prune loadables removed from /config

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ Without it you will see a message `Warning: failed to set thread priority` in th
 | `PERMISSIONS_UMASK`         | `022`                    | [Umask](https://en.wikipedia.org/wiki/Umask) to use for backups, config files and directories                                                                                                                                                                                          |
 | `STEAMCMD_ARGS`             | `validate`               | Additional steamcmd CLI arguments                                                                                                                                                                                                                                                      |
 | `PUBLIC_TEST`               | `false`                  | Run the Public Test Beta version of Valheim server. Note that this simply extends existing `STEAMCMD_ARGS` by adding the appropriate beta flags to it.                                                                                                                                 |
-| `VALHEIM_PLUS`              | `false`                  | Whether [ValheimPlus](https://github.com/valheimPlus/ValheimPlus) mod should be loaded (config in `/config/valheimplus`, additional plugins in `/config/valheimplus/plugins`). Can not be used together with `BEPINEX`.                                                                |
+| `VALHEIM_PLUS`              | `false`                  | Whether [ValheimPlus](https://github.com/valheimPlus/ValheimPlus) mod should be loaded (config in `/config/valheimplus`, additional plugins in `/config/valheimplus/plugins`, patchers in `/config/valheimplus/patchers`). Can not be used together with `BEPINEX`.                    |
 | `VALHEIM_PLUS_REPO`         | `Grantapher/ValheimPlus` | Which ValheimPlus Github repo to use. Useful for switching to forks.                                                                                                                                                                                                                   |
 | `VALHEIM_PLUS_RELEASE`      | `latest`                 | Which version of [ValheimPlus](https://github.com/valheimPlus/ValheimPlus) to download. Will default to latest available. To specify a specific tag set to `tags/0.9.9.8`                                                                                                              |
-| `BEPINEX`                   | `false`                  | Whether [BepInExPack Valheim](https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/) mod should be loaded (config in `/config/bepinex`, plugins in `/config/bepinex/plugins`). Can not be used together with `VALHEIM_PLUS`.                                           |
+| `BEPINEX`                   | `false`                  | Whether [BepInExPack Valheim](https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/) mod should be loaded (config in `/config/bepinex`, plugins in `/config/bepinex/plugins`, patchers in `/config/bepinex/patchers`). Can not be used together with `VALHEIM_PLUS`.   |
 | `SUPERVISOR_HTTP`           | `false`                  | Turn on supervisor's http server                                                                                                                                                                                                                                                       |
 | `SUPERVISOR_HTTP_PORT`      | `9001`                   | Set supervisor's http server port                                                                                                                                                                                                                                                      |
 | `SUPERVISOR_HTTP_USER`      | `admin`                  | Supervisor http server username                                                                                                                                                                                                                                                        |
@@ -743,8 +743,11 @@ Remark: Some Mods are using RPC commands, which needs gameport+2 for communicati
 To enable BepInExPack provide the env variable `BEPINEX=true`. This can not be specified together with `VALHEIM_PLUS=true`.
 Just like Valheim Server this mod is automatically updated using the `UPDATE_CRON` schedule.
 
-Upon first start BepInExPack will create a new directory `/config/bepinex` where its config files are located.
-BepInEx plugins must be copied into the `/config/bepinex/plugins/` directory. From there they will be automatically copied into `/opt/valheim/bepinex/BepInEx/plugins/` on install/update.
+Upon first start, BepInExPack creates a new directory `/config/bepinex` where its config files are located.
+BepInEx plugins must be copied into the `/config/bepinex/plugins/` directory and BepInEx patchers into `/config/bepinex/patchers/`.
+From there they're synced into `/opt/valheim/bepinex/BepInEx/plugins/` and `/opt/valheim/bepinex/BepInEx/patchers/` on container start and on install/update.
+The sync is one-way: a plugin or patcher removed from `/config` is also removed from the server directory on the next sync.
+Only files a previous sync installed are removed, so plugins that came with the mod archive itself and files a patcher generates at runtime (such as HookGenPatcher's `MMHOOK` assemblies) are left alone.
 
 ### Configuration
 
@@ -761,6 +764,7 @@ See [Mod config from Environment Variables](#mod-config-from-environment-variabl
 It has been incorporated into this container. To enable V+ provide the env variable `VALHEIM_PLUS=true`. This can not be specified together with `BEPINEX=true`.
 Upon first start V+ will create a new directory `/config/valheimplus` where its config files are located.
 As a user you are mainly concerned with the values in `/config/valheimplus/valheim_plus.cfg`.
+Additional BepInEx plugins go into `/config/valheimplus/plugins/` and patchers into `/config/valheimplus/patchers/`, synced into the server directory exactly as described under [BepInExPack Valheim](#bepinexpack-valheim).
 For most modifications the mod has to be installed both, on the server as well as all the clients that connect to the server.
 A few modifications can be done server only.
 

--- a/common
+++ b/common
@@ -40,6 +40,8 @@ bepinex_mergefile="$bepinex_download_path/merge" # Signaling file created by val
                                                  # server was updated and needs to be merged
                                                  # with BepInEx
 bepinex_zipfile=BepInEx.zip                      # Name of the BepInEx archive
+bepinex_sync_manifest=.synced_from_config        # Record of what the last /config sync
+                                                 # installed, so it can be pruned later
 
 # Collection of PID files
 valheim_server_pidfile=/var/run/valheim/valheim-server.pid
@@ -278,9 +280,40 @@ write_valheim_plus_config() {
 }
 
 
+sync_bepinex_loadables() {
+    local config_path=${1%/}
+    local bepinex_path=${2%/}
+    local manifest="$bepinex_path/$bepinex_sync_manifest"
+    local dir
+    local stale
+    mkdir -p "$bepinex_path"
+    # Remove only what a previous sync installed. Archive-provided plugins
+    # (ValheimPlus.dll - see #657) and files patchers generate into plugins/
+    # at runtime are absent from the manifest, so they survive.
+    if [ -f "$manifest" ]; then
+        while IFS= read -r stale; do
+            if [ -n "$stale" ] && [ ! -e "$config_path/$stale" ]; then
+                debug "Removing $bepinex_path/$stale - no longer present in $config_path"
+                rm -f "$bepinex_path/$stale"
+            fi
+        done < "$manifest"
+    fi
+    : > "$manifest"
+    for dir in plugins patchers; do
+        # Neither side is guaranteed to exist: the archives stopped shipping these
+        # directories, and an install predating patchers support has no config one.
+        mkdir -p "$config_path/$dir" "$bepinex_path/$dir"
+        info "Syncing BepInEx $dir from $config_path/$dir/ -> $bepinex_path/$dir"
+        rsync -a --itemize-changes "$config_path/$dir/" "$bepinex_path/$dir"
+        # ! -type d not -type f: rsync -a installs symlinks, so record them too
+        (cd "$config_path" && find "$dir" ! -type d -printf '%p\n') >> "$manifest"
+    done
+}
+
+
 write_bepinex_config() {
     local config_path=$1
-    local plugins_path=$2
+    local bepinex_path=$2
     if [ -n "$PRE_BEPINEX_CONFIG_HOOK" ]; then
         info "Running pre BepInEx config hook: $PRE_BEPINEX_CONFIG_HOOK"
         eval "$PRE_BEPINEX_CONFIG_HOOK"
@@ -290,15 +323,7 @@ write_bepinex_config() {
         if env | grep "^$BEPINEX_CFG_ENV_PREFIX" > /dev/null; then
             /usr/local/bin/env2cfg --verbose --config "$config_path/BepInEx.cfg" --env-prefix "$BEPINEX_CFG_ENV_PREFIX"
         fi
-        if [ -d "$config_path/plugins" ]; then
-            # denikson/BepInExPack_Valheim 5.4.2350 stopped shipping the empty
-            # BepInEx/plugins directory that earlier archives provided, so the
-            # destination may not exist after a fresh install and the sync would
-            # otherwise be silently skipped.
-            mkdir -p "$plugins_path"
-            info "Syncing BepInEx plugins from $config_path/plugins/ -> $plugins_path"
-            rsync -a --itemize-changes "$config_path/plugins/" "$plugins_path"
-        fi
+        sync_bepinex_loadables "$config_path" "$bepinex_path"
     fi
     if [ -n "$POST_BEPINEX_CONFIG_HOOK" ]; then
         info "Running post BepInEx config hook: $POST_BEPINEX_CONFIG_HOOK"
@@ -442,8 +467,8 @@ merge_mod() {
     # rsync all mod files on top of the dedicated server files
     rsync -a --itemize-changes "$mod_download_path/" "$mod_install_path.tmp"
     # if /config/<modname>/ does not exist copy the default config from the ZIP archive
-    debug "Ensuring $mod_config_path/plugins exists"
-    mkdir -p "$mod_config_path/plugins"
+    debug "Ensuring $mod_config_path/plugins and $mod_config_path/patchers exist"
+    mkdir -p "$mod_config_path/plugins" "$mod_config_path/patchers"
     pkg_config_dir="$mod_install_path.tmp/BepInEx/config"
     if [ -d "$pkg_config_dir" ]; then
         cd "$pkg_config_dir" || fatal "Could not cd $pkg_config_dir"
@@ -459,7 +484,7 @@ merge_mod() {
             if [ "$config_file" = "valheim_plus.cfg" ]; then
                 write_valheim_plus_config
             elif [ "$config_file" = "BepInEx.cfg" ]; then
-                write_bepinex_config "$mod_config_path" "$mod_install_path.tmp/BepInEx/plugins"
+                write_bepinex_config "$mod_config_path" "$mod_install_path.tmp/BepInEx"
             fi
         done
         cd - || fatal "Could not cd -"

--- a/valheim-bootstrap
+++ b/valheim-bootstrap
@@ -61,7 +61,7 @@ if [ "$VALHEIM_PLUS" = true ]; then
     mkdir -p "$vp_install_path"
     if [ -d "$vp_config_path" ]; then
         write_valheim_plus_config
-        write_bepinex_config "$vp_config_path" "$vp_install_path/BepInEx/plugins"
+        write_bepinex_config "$vp_config_path" "$vp_install_path/BepInEx"
     fi
 fi
 
@@ -69,7 +69,7 @@ if [ "$BEPINEX" = true ]; then
     mkdir -p "$bepinex_download_path"
     mkdir -p "$bepinex_install_path"
     if [ -d "$bepinex_config_path" ]; then
-        write_bepinex_config "$bepinex_config_path" "$bepinex_install_path/BepInEx/plugins"
+        write_bepinex_config "$bepinex_config_path" "$bepinex_install_path/BepInEx"
     fi
 fi
 

--- a/valheim-tests
+++ b/valheim-tests
@@ -22,52 +22,58 @@ test_server_is_crossplay() {
     echo "Crossplay detection tests passed"
 }
 
-# Regression tests for the BepInEx plugin sync, which both the BEPINEX and the
-# VALHEIM_PLUS paths reach through write_bepinex_config().
-#
-# BepInExPack_Valheim 5.4.2350 stopped shipping the empty BepInEx/plugins
-# directory that earlier archives provided. write_bepinex_config() used to
-# require that destination to already exist, so the sync was silently skipped
-# and BepInEx loaded 0 plugins. ValheimPlus rebased onto the same pack and
-# dropped the directory as well - it only still has one because its own
-# ValheimPlus.dll keeps it populated, which is also why the sync must never
-# remove what the archive put there.
-test_bepinex_plugin_sync() {
-    local tmp config_path plugins_path rc=0
+# Checks the /config -> install sync that both BEPINEX and VALHEIM_PLUS reach
+# through write_bepinex_config(). The packs stopped shipping plugins/ or
+# patchers/, so the destinations must be created and pruning must
+# remove only what prior syncs installed, leaving archive-provided plugins
+# (ValheimPlus.dll - see #657) and patcher-generated MMHOOK files alone.
+test_bepinex_loadable_sync() {
+    local tmp config_path bepinex_path rc=0
     tmp=$(mktemp -d)
+    config_path="$tmp/config"
+    bepinex_path="$tmp/install/BepInEx"
 
-    # BepInEx shape: an extracted pack whose BepInEx/ has no plugins/ subdir.
-    config_path="$tmp/bepinex/config"
-    plugins_path="$tmp/bepinex/install/BepInEx/plugins"
-    mkdir -p "$config_path/plugins" "$tmp/bepinex/install/BepInEx"
+    # Stand-ins for the two things pruning must never touch.
+    mkdir -p "$bepinex_path/plugins/MMHOOK"
+    echo "mod" > "$bepinex_path/plugins/ValheimPlus.dll"
+    echo "generated" > "$bepinex_path/plugins/MMHOOK/MMHOOK_assembly_valheim.dll"
+
+    mkdir -p "$config_path/plugins" "$config_path/patchers"
     touch "$config_path/BepInEx.cfg"
     echo "dummy" > "$config_path/plugins/TestPlugin.dll"
-    write_bepinex_config "$config_path" "$plugins_path"
-    if [ ! -f "$plugins_path/TestPlugin.dll" ]; then
-        echo "BepInEx: TestPlugin.dll was not synced to $plugins_path"
+    echo "dummy" > "$config_path/plugins/StalePlugin.dll"
+    echo "dummy" > "$config_path/patchers/TestPatcher.dll"
+
+    write_bepinex_config "$config_path" "$bepinex_path"
+    if [ ! -f "$bepinex_path/plugins/TestPlugin.dll" ]; then
+        echo "TestPlugin.dll was not synced to $bepinex_path/plugins"
+        rc=1
+    fi
+    # patchers/ is absent from the archive, so the sync has to create it.
+    if [ ! -f "$bepinex_path/patchers/TestPatcher.dll" ]; then
+        echo "TestPatcher.dll was not synced to $bepinex_path/patchers"
         rc=1
     fi
 
-    # ValheimPlus shape: the archive ships its own plugin into the destination.
-    config_path="$tmp/valheimplus/config"
-    plugins_path="$tmp/valheimplus/install/BepInEx/plugins"
-    mkdir -p "$config_path/plugins" "$plugins_path"
-    touch "$config_path/BepInEx.cfg"
-    echo "dummy" > "$config_path/plugins/TestPlugin.dll"
-    echo "mod" > "$plugins_path/ValheimPlus.dll"
-    write_bepinex_config "$config_path" "$plugins_path"
-    if [ ! -f "$plugins_path/TestPlugin.dll" ]; then
-        echo "ValheimPlus: TestPlugin.dll was not synced to $plugins_path"
+    # A plugin dropped from /config is pruned; the other two must remain.
+    rm -f "$config_path/plugins/StalePlugin.dll"
+    write_bepinex_config "$config_path" "$bepinex_path"
+    if [ -f "$bepinex_path/plugins/StalePlugin.dll" ]; then
+        echo "StalePlugin.dll was not pruned from $bepinex_path/plugins"
         rc=1
     fi
-    if [ ! -f "$plugins_path/ValheimPlus.dll" ]; then
-        echo "ValheimPlus: ValheimPlus.dll from the archive was removed from $plugins_path"
+    if [ ! -f "$bepinex_path/plugins/ValheimPlus.dll" ]; then
+        echo "ValheimPlus.dll from the archive was pruned from $bepinex_path/plugins"
+        rc=1
+    fi
+    if [ ! -f "$bepinex_path/plugins/MMHOOK/MMHOOK_assembly_valheim.dll" ]; then
+        echo "generated MMHOOK assembly was pruned from $bepinex_path/plugins"
         rc=1
     fi
 
     rm -rf "$tmp"
     if [ "$rc" -eq 0 ]; then
-        echo "BepInEx plugin sync tests passed"
+        echo "BepInEx loadable sync tests passed"
     fi
     return $rc
 }
@@ -117,5 +123,5 @@ main() {
 }
 
 test_server_is_crossplay || exit 1
-test_bepinex_plugin_sync || exit 1
+test_bepinex_loadable_sync || exit 1
 main


### PR DESCRIPTION
Fixes #392.

Syncs `/config/<mod>/patchers/` alongside `plugins/`, creating both. Neither mod archive has shipped them since BepInExPack_Valheim 5.4.2350. Patchers such as HookGenPatcher previously needed a `PRE_START_HOOK` to install; #422 notes Jotunn among the mods that need one.

The sync now prunes as well: remove a plugin from `/config` and it leaves the server directory. `rsync --delete` was tried and reverted (#654, #658) because it deleted `ValheimPlus.dll`, which V+ ships into the same `plugins/` directory users add to (#657) — and deleting everything absent from `/config` fails the same way for files written there at runtime, such as MMHOOK assemblies generated by HookGenPatcher. So each sync instead records what it installed into `BepInEx/.synced_from_config` and the next removes exactly those entries. An install with no manifest prunes nothing and starts recording, so no upgrade can delete a file.

`test_bepinex_loadable_sync` covers both directories, the prune, and the survival of archive-provided and runtime-generated files.
